### PR TITLE
image-storage update & image metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ramsey/uuid": "^3.8",
 		"68publishers/smart-nette-component": "^0.1",
 		"68publishers/doctrine-persistence": "^0.1",
-		"68publishers/image-storage": "^0.1",
+		"68publishers/image-storage": "^0.2",
 		"symfony/event-dispatcher": "^4.0",
 		"kdyby/doctrine": "^3.0",
 		"kdyby/translation": "~2.4"

--- a/src/Control/ImageManager/Configuration.php
+++ b/src/Control/ImageManager/Configuration.php
@@ -24,7 +24,10 @@ final class Configuration
 		'max_file_size' => NULL,
 		'save_manipulator_options' => NULL,
 		'event_subscribers' => [],
-		'thumbnail_preset' => NULL,
+		'thumbnail' => [
+			'preset' => NULL,
+			'descriptor' => NULL,
+		],
 		'dropzone' => [
 			'id' => NULL,
 			'template' => NULL,

--- a/src/Control/ImageManager/ConfiguredImageManagerControlFactory.php
+++ b/src/Control/ImageManager/ConfiguredImageManagerControlFactory.php
@@ -94,9 +94,7 @@ final class ConfiguredImageManagerControlFactory
 			$control->setSaveManipulatorOptions($config->get('save_manipulator_options'));
 		}
 
-		if (is_string($config->get('thumbnail_preset'))) {
-			$control->setThumbnailPreset($config->get('thumbnail_preset'));
-		}
+		$control->setThumbnailOptions($config->get('thumbnail.preset'), $config->get('thumbnail.descriptor'));
 
 		$dispatcher = $control->getEventDispatcher();
 

--- a/src/Control/ImageManager/ImageManagerControl.php
+++ b/src/Control/ImageManager/ImageManagerControl.php
@@ -54,6 +54,9 @@ final class ImageManagerControl extends SixtyEightPublishers\SmartNetteComponent
 	/** @var string|NULL */
 	private $thumbnailPreset;
 
+	/** @var \SixtyEightPublishers\ImageStorage\Responsive\Descriptor\IDescriptor|NULL */
+	private $thumbnailDescriptor;
+
 	/**
 	 * @param \SixtyEightPublishers\ImageBundle\Storage\IDataStorage                     $dataStorage
 	 * @param \SixtyEightPublishers\ImageBundle\Control\DropZone\IDropZoneControlFactory $dropZoneControlFactory
@@ -171,6 +174,7 @@ final class ImageManagerControl extends SixtyEightPublishers\SmartNetteComponent
 		$this->template->allowUpload = $allowUpload = (NULL === $maxFiles || $maxFiles > 0);
 		$this->template->denyUpload = !$allowUpload;
 		$this->template->thumbnailPreset = $this->thumbnailPreset;
+		$this->template->thumbnailDescriptor = $this->thumbnailDescriptor;
 
 		$this->doRender();
 	}
@@ -229,13 +233,15 @@ final class ImageManagerControl extends SixtyEightPublishers\SmartNetteComponent
 	}
 
 	/**
-	 * @param string $thumbnailPreset
+	 * @param string|NULL                                                               $preset
+	 * @param \SixtyEightPublishers\ImageStorage\Responsive\Descriptor\IDescriptor|NULL $descriptor
 	 *
 	 * @return \SixtyEightPublishers\ImageBundle\Control\ImageManager\ImageManagerControl
 	 */
-	public function setThumbnailPreset(string $thumbnailPreset): self
+	public function setThumbnailOptions(?string $preset, ?SixtyEightPublishers\ImageStorage\Responsive\Descriptor\IDescriptor $descriptor = NULL): self
 	{
-		$this->thumbnailPreset = $thumbnailPreset;
+		$this->thumbnailPreset = $preset;
+		$this->thumbnailDescriptor = $descriptor;
 
 		return $this;
 	}

--- a/src/Control/ImageManager/templates/ImageManagerControl.latte
+++ b/src/Control/ImageManager/templates/ImageManagerControl.latte
@@ -30,7 +30,11 @@
 						</div>
 					</div>
 
-					<img class="img-fluid img-thumbnail" n:srcset="$image->getSource(), $thumbnailPreset" alt="">
+					{if NULL !== $thumbnailDescriptor}
+						<img class="img-fluid img-thumbnail" n:srcset="$image->getSource(), $thumbnailDescriptor, $thumbnailPreset" alt="">
+                    {else}
+						<img class="img-fluid img-thumbnail" n:img="$image->getSource(), $thumbnailPreset" alt="">
+                    {/if}
 				</div>
 			</div>
 		</div>

--- a/src/DI/ImageBundleExtension.php
+++ b/src/DI/ImageBundleExtension.php
@@ -18,6 +18,7 @@ final class ImageBundleExtension extends Nette\DI\CompilerExtension implements
 	private $defaults = [
 		'image_entity' => SixtyEightPublishers\ImageBundle\DoctrineEntity\Basic\Image::class, # or array [entity => class name, mapping: array]
 		'image_entity_factory' => NULL,
+		'resource_metadata_factory' => SixtyEightPublishers\ImageBundle\ResourceMetadata\ResourceMetadataFactory::class,
 		'data_storage_factory' => SixtyEightPublishers\ImageBundle\Storage\DataStorageFactory::class,
 		'image_managers' => [],
 		'templates' => [
@@ -47,6 +48,7 @@ final class ImageBundleExtension extends Nette\DI\CompilerExtension implements
 		Nette\Utils\Validators::assertField($config, 'image_managers', 'array[]');
 
 		$this->registerImageEntityFactory($builder, $config);
+		$this->registerResourceMetadataFactory($builder, $config);
 		$this->registerDataStorageFactory($builder, $config);
 
 		$builder->addDefinition($this->prefix('event_subscriber.delete_image_source'))
@@ -141,6 +143,26 @@ final class ImageBundleExtension extends Nette\DI\CompilerExtension implements
 			$builder->addDefinition($this->prefix('image_entity_factory'))
 				->setType(SixtyEightPublishers\ImageBundle\EntityFactory\IImageEntityFactory::class)
 				->setFactory($imageEntityFactory);
+		}
+	}
+
+	/**
+	 * @param \Nette\DI\ContainerBuilder $builder
+	 * @param array                      $config
+	 *
+	 * @return void
+	 * @throws \Nette\Utils\AssertionException
+	 */
+	private function registerResourceMetadataFactory(Nette\DI\ContainerBuilder $builder, array $config): void
+	{
+		Nette\Utils\Validators::assertField($config, 'resource_metadata_factory', 'string|' . Nette\DI\Statement::class);
+
+		$resourceMetadataFactory = $config['resource_metadata_factory'];
+
+		if ($this->needRegister($resourceMetadataFactory)) {
+			$builder->addDefinition($this->prefix('resource_metadata_factory'))
+				->setType(SixtyEightPublishers\ImageBundle\ResourceMetadata\IResourceMetadataFactory::class)
+				->setFactory($resourceMetadataFactory);
 		}
 	}
 

--- a/src/DI/ImageManagerConfigurationStatementFactory.php
+++ b/src/DI/ImageManagerConfigurationStatementFactory.php
@@ -98,7 +98,9 @@ final class ImageManagerConfigurationStatementFactory
 			}
 		});
 		
-		$this->validateIfKeyExists($options, 'thumbnail_preset', 'null|string');
+		$this->validateIfKeyExists($options, 'thumbnail.preset', 'null|string');
+
+		$this->validateIfKeyExists($options, 'thumbnail.descriptor', 'null|' . Nette\DI\Statement::class);
 
 		$this->validateIfKeyExists($options, 'dropzone.id', 'null|string');
 

--- a/src/DoctrineEntity/AbstractImage.php
+++ b/src/DoctrineEntity/AbstractImage.php
@@ -45,6 +45,13 @@ abstract class AbstractImage implements IImage
 	protected $source;
 
 	/**
+	 * @ORM\Column(type="json")
+	 *
+	 * @var array
+	 */
+	protected $metadata = [];
+
+	/**
 	 * @param \SixtyEightPublishers\ImageStorage\DoctrineType\ImageInfo\ImageInfo $info
 	 * @param \Ramsey\Uuid\UuidInterface|NULL                                     $uuid
 	 *
@@ -102,10 +109,6 @@ abstract class AbstractImage implements IImage
 		return rtrim(strtr(base64_encode($version), '+/', '-_'), '=');
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-
 	/***************** interface \SixtyEightPublishers\ImageBundle\DoctrineEntity\IImage *****************/
 
 	/**
@@ -130,6 +133,26 @@ abstract class AbstractImage implements IImage
 	public function getCreated(): \DateTime
 	{
 		return $this->created;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getMetadata(string $key = NULL, $default = NULL)
+	{
+		if (NULL === $key) {
+			return $this->metadata;
+		}
+
+		return $this->metadata[$key] ?? $default;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setMetadata(array $metadata): void
+	{
+		$this->metadata = $metadata;
 	}
 
 	/**

--- a/src/DoctrineEntity/IImage.php
+++ b/src/DoctrineEntity/IImage.php
@@ -24,6 +24,21 @@ interface IImage
 	public function getCreated(): \DateTime;
 
 	/**
+	 * @param string|NULL $key
+	 * @param mixed|NULL  $default
+	 *
+	 * @return mixed|array|NULL
+	 */
+	public function getMetadata(string $key = NULL, $default = NULL);
+
+	/**
+	 * @param array $metadata
+	 *
+	 * @return void
+	 */
+	public function setMetadata(array $metadata): void;
+
+	/**
 	 * Updates the version of a source and a `updated` field
 	 *
 	 * @return void

--- a/src/ResourceMetadata/IResourceMetadataFactory.php
+++ b/src/ResourceMetadata/IResourceMetadataFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\ImageBundle\ResourceMetadata;
+
+use SixtyEightPublishers;
+
+interface IResourceMetadataFactory
+{
+	/**
+	 * @param \SixtyEightPublishers\ImageStorage\Resource\IResource $resource
+	 *
+	 * @return array
+	 */
+	public function create(SixtyEightPublishers\ImageStorage\Resource\IResource $resource): array;
+}

--- a/src/ResourceMetadata/MetadataName.php
+++ b/src/ResourceMetadata/MetadataName.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\ImageBundle\ResourceMetadata;
+
+use Nette;
+
+/**
+ * Enum with names of basic metadata.
+ */
+final class MetadataName
+{
+	use Nette\StaticClass;
+
+	public const    WIDTH = 'width',
+					HEIGHT = 'height',
+					MIME = 'mime';
+}

--- a/src/ResourceMetadata/ResourceMetadataFactory.php
+++ b/src/ResourceMetadata/ResourceMetadataFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\ImageBundle\ResourceMetadata;
+
+use SixtyEightPublishers;
+
+class ResourceMetadataFactory implements IResourceMetadataFactory
+{
+	/*********** interface \SixtyEightPublishers\ImageBundle\ResourceMetadata\IResourceMetadataFactory ***********/
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function create(SixtyEightPublishers\ImageStorage\Resource\IResource $resource): array
+	{
+		$image = $resource->getImage();
+
+		return [
+			MetadataName::WIDTH => $image->width(),
+			MetadataName::HEIGHT => $image->height(),
+			MetadataName::MIME => $image->mime(),
+		];
+	}
+}

--- a/src/Storage/Manipulator/Options/SaveManipulatorOptions.php
+++ b/src/Storage/Manipulator/Options/SaveManipulatorOptions.php
@@ -20,6 +20,9 @@ class SaveManipulatorOptions
 	/** @var NULL|callable */
 	private $transactionExtensionCallback;
 
+	/** @var array  */
+	private $customMetadata = [];
+
 	/**
 	 * @param string $namespace
 	 *
@@ -77,6 +80,27 @@ class SaveManipulatorOptions
 	}
 
 	/**
+	 * @param array $metadata
+	 *
+	 * @return void
+	 */
+	public function setCustomMetadata(array $metadata): void
+	{
+		$this->customMetadata = $metadata;
+	}
+
+	/**
+	 * @param string $name
+	 * @param mixed  $value
+	 *
+	 * @return void
+	 */
+	public function addCustomMetadata(string $name, $value): void
+	{
+		$this->customMetadata[$name] = $value;
+	}
+
+	/**
 	 * @param \Nette\Http\FileUpload $fileUpload
 	 *
 	 * @return string
@@ -120,5 +144,13 @@ class SaveManipulatorOptions
 
 			$cb($transaction);
 		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getCustomMetadata(): array
+	{
+		return $this->customMetadata;
 	}
 }


### PR DESCRIPTION
- updated `68publishers/image-storage` to version `^0.2`
- added basic image matadata - `width`, `height` and `mime`. Data are saved on `Image` entity during upload
